### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: msfjarvis/setup-android@0.2
-        with:
-          gradleTasks: testDebug
+      - run: ./gradlew testDebug
         env:
           tmdb_api_key: '"TMDB_API_KEY"'


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.
﻿